### PR TITLE
Use remoteService's hostname instead of referrer IP

### DIFF
--- a/src/keyLight.ts
+++ b/src/keyLight.ts
@@ -2,7 +2,7 @@ import { Logger } from 'homebridge';
 import axios from 'axios';
 
 export interface KeyLight {
-  ip: string;
+  hostname: string;
   port: number;
   name: string;
   mac: string;
@@ -45,7 +45,7 @@ export interface KeyLightOptions {
 
 export class KeyLightInstance {
   private constructor(keyLight: KeyLight, log: Logger, pollingRate: number) {
-    this.ip = keyLight.ip;
+    this.hostname = keyLight.hostname;
     this.port = keyLight.port;
     this.name = keyLight.name;
     this.mac = keyLight.mac;
@@ -57,7 +57,7 @@ export class KeyLightInstance {
   private readonly log: Logger;
   private readonly pollingRate: number;
 
-  private _onPropertyChanged: (arg1: ('brightness' | 'on' | 'temperature'), arg2: number) => void = 
+  private _onPropertyChanged: (arg1: ('brightness' | 'on' | 'temperature'), arg2: number) => void =
   () => {
     true;
   }
@@ -103,7 +103,7 @@ export class KeyLightInstance {
   }
 
   public get endpoint(): string {
-    return 'http://' + this.ip + ':' + this.port + '/elgato/';
+    return 'http://' + this.hostname + ':' + this.port + '/elgato/';
   }
 
   public get infoEndpoint(): string {
@@ -167,7 +167,7 @@ export class KeyLightInstance {
           if (this.options) {
             const oldLight = this.options.lights[0];
             const newLight = response.data.lights[0];
-        
+
             if (oldLight.on !== newLight.on) {
               this._onPropertyChanged('on', newLight.on);
             }
@@ -186,5 +186,5 @@ export class KeyLightInstance {
           true;
         });
     }, this.pollingRate);
-  }  
+  }
 }

--- a/src/keyLightsAccessory.ts
+++ b/src/keyLightsAccessory.ts
@@ -33,13 +33,13 @@ export class KeyLightsAccessory {
 
     // register handlers for the On/Off Characteristic
     this.service.getCharacteristic(this.platform.Characteristic.On)
-      .on('set', this.setOn.bind(this))         
-      .on('get', this.getOn.bind(this));        
+      .on('set', this.setOn.bind(this))
+      .on('get', this.getOn.bind(this));
 
     // register handlers for the Brightness Characteristic
     this.service.getCharacteristic(this.platform.Characteristic.Brightness)
-      .on('set', this.setBrightness.bind(this)) 
-      .on('get', this.getBrightness.bind(this));      
+      .on('set', this.setBrightness.bind(this))
+      .on('get', this.getBrightness.bind(this));
 
     // register handlers for the Color Temperature Characteristic and set the valid value range
     this.service.getCharacteristic(this.platform.Characteristic.ColorTemperature)
@@ -121,7 +121,7 @@ export class KeyLightsAccessory {
     this.platform.log.debug('Updating property', property, 'of device', this.accessory.displayName, 'to', value);
     switch (property) {
       case 'on':
-        this.service.updateCharacteristic(this.platform.Characteristic.On, value);   
+        this.service.updateCharacteristic(this.platform.Characteristic.On, value);
         break;
       case 'temperature':
         this.service.updateCharacteristic(this.platform.Characteristic.ColorTemperature, value);
@@ -139,7 +139,7 @@ export class KeyLightsAccessory {
    * Called from platform handler when the light got a new IP address
    */
   updateConnectionData(data: KeyLight) {
-    this.light.ip = data.ip;
+    this.light.hostname = data.hostname;
     this.light.port = data.port;
   }
 }

--- a/src/keyLightsPlatfom.ts
+++ b/src/keyLightsPlatfom.ts
@@ -27,11 +27,11 @@ export class KeyLightsPlatform implements DynamicPlatformPlugin {
     this.api.on('didFinishLaunching', () => {
       this.log.debug('Executed didFinishLaunching callback');
 
-      stw.on('up', (remoteService, _, referrer) => {
+      stw.on('up', (remoteService) => {
         this.log.debug('Discovered accessory:', remoteService.name);
 
         const light: KeyLight = {
-          ip: referrer.address,
+          hostname: remoteService.hostname,
           port: remoteService.port,
           name: remoteService.name,
           mac: remoteService.txt?.['id'] as string ?? '',
@@ -79,9 +79,9 @@ export class KeyLightsPlatform implements DynamicPlatformPlugin {
     light.updateSettings({
       powerOnBehavior: this.config.powerOnBehavior ?? light.settings?.powerOnBehavior ?? 1,
       powerOnBrightness: this.config.powerOnBrightness ?? light.settings?.powerOnBrightness ?? 20,
-      powerOnTemperature: this.config.powerOnTemperature 
-        ? Math.round(1000000/this.config.powerOnTemperature) 
-        : light.settings?.powerOnTemperature 
+      powerOnTemperature: this.config.powerOnTemperature
+        ? Math.round(1000000/this.config.powerOnTemperature)
+        : light.settings?.powerOnTemperature
         ?? 213,
       switchOnDurationMs: this.config.switchOnDurationMs ?? light.settings?.switchOnDurationMs ?? 100,
       switchOffDurationMs: this.config.switchOffDurationMs ?? light.settings?.switchOffDurationMs ?? 300,


### PR DESCRIPTION
In an environment with an mDNS "reflector" or repeater service (such as a Ubiquiti Unifi network), the `referrer` is not the actual target device but a network device. Therefore, its IP would be e.g. that of a router in the network.

Instead, it should be much safer to simply use the remoteService's hostname and let regular DNS resolution figure out its IP address.

Alternatively, `remoteService` also has a `addresses` property which contains the device's IP address(es) but imo using regular DNS to resolve the hostname is the preferred solution, unless it causes issues I have not experienced in my local testing.